### PR TITLE
Move ntfy functionality to script

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -6,7 +6,7 @@ on:
     - main
       
   schedule:
-    - cron: '5 12 * * *'
+    - cron: '0 * * * *'
 
   workflow_dispatch:
 

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -35,11 +35,11 @@ jobs:
           message: "action: update car data"
           default_author: github_actions
       
-      - name: Get sha of latest commit and send notification
-        run: >
-          curl 
-          -H "Title: Car Repo Scraper" 
-          -H "Tags: car" 
-          -H "Click: https://github.com/sphars/car-repo-scraper/commit/${{ steps.commit_and_push.outputs.commit_sha }}/" 
-          -d "Data updated" 
-          ntfy.sh/car-repo-scraper
+      # - name: Get sha of latest commit and send notification
+      #   run: >
+      #     curl 
+      #     -H "Title: Car Repo Scraper" 
+      #     -H "Tags: car" 
+      #     -H "Click: https://github.com/sphars/car-repo-scraper/commit/${{ steps.commit_and_push.outputs.commit_sha }}/" 
+      #     -d "Data updated" 
+      #     ntfy.sh/car-repo-scraper

--- a/cars.json
+++ b/cars.json
@@ -1,92 +1,95 @@
-[
-    {
-        "title": "2014 Chevrolet Impala LTZ",
-        "details": "103,377 Miles Automatic FWD 3.6L V-6",
-        "bid_price": "$14,601",
-        "bin_price": "$16,800",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/623ce41559303.jpeg",
-        "url": "https://repos.americafirst.com/units/1562",
-        "source": "AFCU"
-    },
-    {
-        "title": "2019 Dodge Grand Caravan GT",
-        "details": "72,047 Miles Automatic FWD 3.6L V-6",
-        "bid_price": "$22,379",
-        "bin_price": "$25,650",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c7e1ce1e66.jpeg",
-        "url": "https://repos.americafirst.com/units/1573",
-        "source": "AFCU"
-    },
-    {
-        "title": "2014 Ford F-150 Lariat",
-        "details": "135,051 Miles Automatic 4X4 3.5L V-6",
-        "bid_price": "$20,301",
-        "bin_price": "$23,280",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/620ff2a1c21ec.jpeg",
-        "url": "https://repos.americafirst.com/units/1528",
-        "source": "AFCU"
-    },
-    {
-        "title": "2021 FOREST RIVER V-TEC VTV1",
-        "details": "",
-        "bid_price": "$14,075",
-        "bin_price": "$16,300",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/621011d09ee55.jpeg",
-        "url": "https://repos.americafirst.com/units/1529",
-        "source": "AFCU"
-    },
-    {
-        "title": "2016 Forest River/Palomino Real-Lite 18X",
-        "details": "",
-        "bid_price": "$15,705",
-        "bin_price": "$19,200",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c86c70b239.jpeg",
-        "url": "https://repos.americafirst.com/units/1578",
-        "source": "AFCU"
-    },
-    {
-        "title": "2018 Harley-Davidson Softail Fat Boy 114",
-        "details": "8,071 Miles 1,753cc",
-        "bid_price": "$16,000",
-        "bin_price": "$18,400",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c853bc0e5e.jpeg",
-        "url": "https://repos.americafirst.com/units/1577",
-        "source": "AFCU"
-    },
-    {
-        "title": "2006 Honda VTX 1300 C",
-        "details": "30,063 Miles 1,312cc",
-        "bid_price": "$3,000",
-        "bin_price": "$3,500",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c846300ee3.jpeg",
-        "url": "https://repos.americafirst.com/units/1576",
-        "source": "AFCU"
-    },
-    {
-        "title": "2018 INFINITI Q60 3.0T Sport",
-        "details": "50,763 Miles Automatic AWD 3.0L V-6",
-        "bid_price": "$34,500",
-        "bin_price": "$38,400",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c7c5fb2bc3.jpeg",
-        "url": "https://repos.americafirst.com/units/1572",
-        "source": "AFCU"
-    },
-    {
-        "title": "2016 Nissan Rogue SV",
-        "details": "92,500 Miles CVT AWD 2.5L I-4",
-        "bid_price": "$13,650",
-        "bin_price": "$16,995",
-        "bid_end_date": "4/20/22 9:00 AM",
-        "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c823bdaba6.jpeg",
-        "url": "https://repos.americafirst.com/units/1575",
-        "source": "AFCU"
-    }
-]
+{
+    "last_updated": "2022-04-17 21:53:36 MDT",
+    "cars": [
+        {
+            "title": "2014 Chevrolet Impala LTZ",
+            "details": "103,377 Miles Automatic FWD 3.6L V-6",
+            "bid_price": "$14,601",
+            "bin_price": "$16,800",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/623ce41559303.jpeg",
+            "url": "https://repos.americafirst.com/units/1562",
+            "source": "AFCU"
+        },
+        {
+            "title": "2019 Dodge Grand Caravan GT",
+            "details": "72,047 Miles Automatic FWD 3.6L V-6",
+            "bid_price": "$22,379",
+            "bin_price": "$25,650",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c7e1ce1e66.jpeg",
+            "url": "https://repos.americafirst.com/units/1573",
+            "source": "AFCU"
+        },
+        {
+            "title": "2014 Ford F-150 Lariat",
+            "details": "135,051 Miles Automatic 4X4 3.5L V-6",
+            "bid_price": "$20,301",
+            "bin_price": "$23,280",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/620ff2a1c21ec.jpeg",
+            "url": "https://repos.americafirst.com/units/1528",
+            "source": "AFCU"
+        },
+        {
+            "title": "2021 FOREST RIVER V-TEC VTV1",
+            "details": "",
+            "bid_price": "$14,075",
+            "bin_price": "$16,300",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/621011d09ee55.jpeg",
+            "url": "https://repos.americafirst.com/units/1529",
+            "source": "AFCU"
+        },
+        {
+            "title": "2016 Forest River/Palomino Real-Lite 18X",
+            "details": "",
+            "bid_price": "$15,705",
+            "bin_price": "$19,200",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c86c70b239.jpeg",
+            "url": "https://repos.americafirst.com/units/1578",
+            "source": "AFCU"
+        },
+        {
+            "title": "2018 Harley-Davidson Softail Fat Boy 114",
+            "details": "8,071 Miles 1,753cc",
+            "bid_price": "$16,000",
+            "bin_price": "$18,400",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c853bc0e5e.jpeg",
+            "url": "https://repos.americafirst.com/units/1577",
+            "source": "AFCU"
+        },
+        {
+            "title": "2006 Honda VTX 1300 C",
+            "details": "30,063 Miles 1,312cc",
+            "bid_price": "$3,100",
+            "bin_price": "",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c846300ee3.jpeg",
+            "url": "https://repos.americafirst.com/units/1576",
+            "source": "AFCU"
+        },
+        {
+            "title": "2018 INFINITI Q60 3.0T Sport",
+            "details": "50,763 Miles Automatic AWD 3.0L V-6",
+            "bid_price": "$34,500",
+            "bin_price": "$38,400",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c7c5fb2bc3.jpeg",
+            "url": "https://repos.americafirst.com/units/1572",
+            "source": "AFCU"
+        },
+        {
+            "title": "2016 Nissan Rogue SV",
+            "details": "92,500 Miles CVT AWD 2.5L I-4",
+            "bid_price": "$14,000",
+            "bin_price": "$16,995",
+            "bid_end_date": "4/20/22 9:00 AM",
+            "image": "https://repos.americafirst.com/storage/images/unit-pictures/624c823bdaba6.jpeg",
+            "url": "https://repos.americafirst.com/units/1575",
+            "source": "AFCU"
+        }
+    ]
+}

--- a/script.py
+++ b/script.py
@@ -1,11 +1,8 @@
-from types import new_class
 import requests as r
-import json
-import re
+import json, re
 from bs4 import BeautifulSoup
 from datetime import datetime
 from zoneinfo import ZoneInfo
-
 
 def getAFCUCars():
     afcu_url = 'https://repos.americafirst.com'
@@ -58,7 +55,7 @@ def getNewCars(current_cars):
         previous_cars = json.load(f)
 
     # get the set of unique urls in list of previous cars
-    previous_cars_bucket = set(car["url"] for car in previous_cars)
+    previous_cars_bucket = set(car["url"] for car in previous_cars['cars'])
     
     # get the list of cars from current cars by set of urls
     new_cars = []
@@ -68,8 +65,9 @@ def getNewCars(current_cars):
 
 def sendNotifications(new_cars):
     for car in new_cars:
+        data = "{0} | {1}\n{2}".format(car['title'], car['bin_price'] or car['bid_price'], car['details'])
         r.post("https://ntfy.sh/car-repo-scraper",
-            data=f"{car['title']} - {car['details']} - {car['bin_price']}",
+            data=data,
             headers={
                 "Title": "New Car Posted",
                 "Tags": "car",
@@ -79,16 +77,21 @@ def sendNotifications(new_cars):
 
 
 def writeData(list_of_cars):    
-    #current_datetime = datetime.now(ZoneInfo("US/Mountain")).strftime("%Y-%m-%d %H:%M:%S %Z")
+    current_datetime = datetime.now(ZoneInfo("US/Mountain")).strftime("%Y-%m-%d %H:%M:%S %Z")
+    final_data = {
+        "last_updated": current_datetime,
+        "cars": list_of_cars
+    }
     with open('cars.json', 'w') as f:
-        json.dump(list_of_cars, f, indent=4)
+        json.dump(final_data, f, indent=4)
 
 def main():
     current_cars = []
     current_cars += getAFCUCars()
 
     new_cars = getNewCars(current_cars)
-    sendNotifications(new_cars)
+    if(new_cars):
+        sendNotifications(new_cars)
     writeData(current_cars)
 
 


### PR DESCRIPTION
Instead of notifying when any data changes, only send a notification when a new car is posted. This moves the ntfy.sh functionality to the script rather than in GH Actions, since the data is already being processed in the script. Further, it allows for more modularity when new repo sources are added.

Closes #1 